### PR TITLE
Add docker compose setup with PostgreSQL and app container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+build
+*.o
+*.out
+*.log
+.env
+.vscode
+.idea

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_DB=sis
+POSTGRES_USER=sis_user
+POSTGRES_PASSWORD=sis_pass

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    pkg-config \
+    libpqxx-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY CMakeLists.txt ./
+COPY src ./src
+COPY include ./include
+
+RUN cmake -S . -B build && cmake --build build -j
+
+CMD ["./build/sis_app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  db:
+    image: postgres:16
+    container_name: sis-db
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-sis}
+      POSTGRES_USER: ${POSTGRES_USER:-sis_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-sis_pass}
+    volumes:
+      - sis_db_data:/var/lib/postgresql
+    networks:
+      - sis_net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: sis-app
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: ${POSTGRES_DB:-sis}
+      DB_USER: ${POSTGRES_USER:-sis_user}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-sis_pass}
+    networks:
+      - sis_net
+
+volumes:
+  sis_db_data:
+
+networks:
+  sis_net:
+    driver: bridge


### PR DESCRIPTION
This PR adds Docker infrastructure for the project.

Includes:
- docker-compose.yml (PostgreSQL v16 + app, volume, network, healthcheck)
- Dockerfile to build and run C++ app (sis_app)
- .dockerignore
- .env.example

Tested with:
- docker compose up -d db
- docker exec -it sis-db psql -U sis_user -d sis -c "SELECT 1;"
