### PR TITLE
feat(db): add custom PostgreSQL image and compose build config (week2)

### DIFF
--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,1 @@
+FROM postgres:16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
+version: "3.9"
+
 services:
   db:
-    image: postgres:16
+    build:
+      context: .
+      dockerfile: Dockerfile.db
+    image: hilalb/sis-db:week2
     container_name: sis-db
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-sis}
@@ -20,6 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: hilalb/sis-app:week2
     container_name: sis-app
     depends_on:
       db:


### PR DESCRIPTION
Adds a custom PostgreSQL Docker image for Week 2.

Changes:
- Adds Dockerfile.db for PostgreSQL image
- Updates docker-compose.yml to build db image from Dockerfile.db
- Tags db image as hilalb/sis-db:week2
- Keeps healthcheck, volume, and network configuration intact

How to test:
docker compose up -d --build db
docker exec -it sis-db psql -U sis_user -d sis -c "SELECT 1;"

Docker Hub: hilalb/sis-db:week2
Closes #17


