### PR TITLE
fix(app): disable tests during Docker image build (BUILD_TESTS=OFF)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,15 +32,20 @@ target_link_libraries(sis_app
     PRIVATE sis_core
 )
 
-# Tests
-enable_testing()
 
-add_executable(test_basic
-    tests/test_basic.cpp
-)
+# Tests (optional)
+option(BUILD_TESTS "Build tests" ON)
 
-target_link_libraries(test_basic
-    PRIVATE sis_core
-)
+if(BUILD_TESTS)
+    enable_testing()
 
-add_test(NAME basic_test COMMAND test_basic)
+    add_executable(test_basic
+        tests/test_basic.cpp
+    )
+
+    target_link_libraries(test_basic
+        PRIVATE sis_core
+    )
+
+    add_test(NAME basic_test COMMAND test_basic)
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY CMakeLists.txt ./
 COPY src ./src
 COPY include ./include
 
-RUN cmake -S . -B build && cmake --build build -j
+RUN cmake -S . -B build -DBUILD_TESTS=OFF && cmake --build build -j
 
 CMD ["./build/sis_app"]


### PR DESCRIPTION
Summary
- Prevents Docker image build from failing when tests are not present/needed.
- Makes test targets optional via BUILD_TESTS flag.

Changes
- CMake: wrap test setup (enable_testing + test_basic target + add_test) with `if(BUILD_TESTS)`
- Dockerfile: build the app with `-DBUILD_TESTS=OFF` to skip tests during image build

How to test
- Docker build:
  docker compose build app --no-cache
- CI/Local tests (optional):
  cmake -S . -B build -DBUILD_TESTS=ON
  cmake --build build
  ctest --test-dir build

Notes
- Tests remain enabled for CI by setting BUILD_TESTS=ON in the workflow.

Closes #18

